### PR TITLE
Managing Branches Edits - Zito

### DIFF
--- a/content/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop.md
+++ b/content/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop.md
@@ -62,7 +62,11 @@ If you create a branch on {% data variables.product.product_name %}, you'll need
 
 ## Switching between branches
 
-You can view and make commits to any of your repository's branches. If you have uncommitted, saved changes, you'll need to decide what to do with your changes before you can switch branches. You can commit your changes on the current branch, stash your changes to temporarily save them on the current branch, or bring the changes to your new branch. If you want to commit your changes before switching branches, see "[AUTOTITLE](/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop)."
+You can view and make commits to any of your repository's branches. 
+
+> **Note**: If you have uncommitted, saved changes, you'll need to decide what to do with your changes before you can switch branches. You can commit your changes on the current branch, stash your changes to temporarily save them on the current branch, or bring the changes to your new branch. 
+
+If you want to commit your changes before switching branches, see "[AUTOTITLE](/desktop/making-changes-in-a-branch/committing-and-reviewing-changes-to-your-project-in-github-desktop)."
 {% tip %}
 
 **Tip**: You can set a default behavior for switching branches in the **Prompts** settings. For more information, see "[AUTOTITLE](/desktop/configuring-and-customizing-github-desktop/configuring-basic-settings-in-github-desktop)."
@@ -75,7 +79,9 @@ You can view and make commits to any of your repository's branches. If you have 
 
 ## Deleting a branch
 
-You can't delete a branch if it's currently associated with an open pull request. You cannot undo deleting a branch.
+You can't delete a branch if it's currently associated with an open pull request. 
+
+**Note**: You cannot undo deleting a branch.
 
 {% mac %}
 

--- a/content/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop.md
+++ b/content/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop.md
@@ -39,7 +39,6 @@ You can always create a branch in {% data variables.product.prodname_desktop %} 
    ![Screenshot of the "Current Branch" dropdown view. Next to the "Filter" field, a button, labeled "New Branch", is outlined in orange.](/assets/images/help/desktop/new-branch-button-mac.png)
 
 {% data reusables.desktop.name-branch %}
-{% data reusables.desktop.select-base-branch %}
 {% data reusables.desktop.confirm-new-branch-button %}
 
 ## Creating a branch from a previous commit

--- a/content/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop.md
+++ b/content/desktop/making-changes-in-a-branch/managing-branches-in-github-desktop.md
@@ -25,14 +25,6 @@ Once you're satisfied with your work, you can create a pull request to merge you
 
 You can always create a branch in {% data variables.product.prodname_desktop %} if you have read access to a repository, but you can only push the branch to {% data variables.product.prodname_dotcom %} if you have write access to the repository.
 
-{% data reusables.desktop.protected-branches %}
-
-{% ifversion repo-rules %}
-
-Repository administrators can also enable rulesets. Rulesets can be used to require specific branch names when creating a new branch, or to allow only users with bypass permissions to publish a new branch to the remote repository. {% data variables.product.prodname_desktop %} will show a warning and prevent the branch from being created if the branch does not follow the rulesets. For more information, see "[AUTOTITLE](/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)."
-
-{% endif %}
-
 ## Creating a branch
 
 {% tip %}

--- a/data/reusables/desktop/click-base-branch-in-drop-down.md
+++ b/data/reusables/desktop/click-base-branch-in-drop-down.md
@@ -1,3 +1,4 @@
-1. At the top of the app, click {% octicon "git-branch" aria-hidden="true" %} **Current Branch** and then in the list of branches, click the branch that you want to base your new branch on.
+   1. At the top of the app, click {% octicon "git-branch" aria-hidden="true" %} **Current Branch**
+      1.  In the list of branches, click the branch that you want to base your new branch on.
 
    ![Screenshot of the "Current Branch" dropdown view. Under "Recent Branches", a branch, named "my-feature", is highlighted with an orange outline.](/assets/images/help/desktop/select-branch-from-dropdown.png)

--- a/data/reusables/desktop/name-branch.md
+++ b/data/reusables/desktop/name-branch.md
@@ -1,1 +1,1 @@
-1. In the "Create a Branch" window, under "Name", type the name of the new branch.
+1. In the "Create a Branch" window, type the name of the new branch.


### PR DESCRIPTION
# Pull Request

#### Edited Managing Branches in GitHub file

## Staging

The follow content was changed to support a novice technical communicator:

### Writing for intended audience
* Removed information for repo administrators that a novice user is not interested in

### Focus on users' goals
  * Would this be applicable to the goals of a technical communicator using GitHub to make documents?
  >You can also create a branch starting from a previous commit in a branch's history. This can be helpful if you need to return to an earlier view of the repository to investigate a bug, or to create a hot fix on top of your latest release.
 * If this isn't useful for TC then the section about creating a branch from a previous commit could be removed.

## Coaching

Made the information easier to follow for someone without GitHub experience

### Practical reasons for supporting information
* Removed some unecessary/redundant information about naming branches
  * > 1. In the "Create a Branch" window, ~~under "Name",~~ type the name of the new branch.
* Removed repetitive information about selecting a base branch
### Provides clear, step-by-step instruction
 * Broke up some instructions to be more clear and easily read.
    * ex. divided this step into two parts
    * >1. At the top of the app, click {% octicon "git-branch" aria-hidden="true" %} **Current Branch**  
    * >2. In the list of branches, click the branch that you want to base your new branch on.

## Alerting

Added clear alerts about deleting and switching branches.

### Provides clear, step-by-step instruction
* Clearly alerted readers that they cannot switch branches with uncommitted changes without additional actions. 
* Emphasized that users cannot undo deleting a branch